### PR TITLE
Fixes mkdocs deprecation warnings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,8 +148,8 @@ markdown_extensions:
   - pymdownx.arithmatex:      # Preserve LaTeX math equations       https://facelessuser.github.io/pymdown-extensions/extensions/arithmatex/
       generic: true
   - pymdownx.emoji:           # Emojis                              https://facelessuser.github.io/pymdown-extensions/extensions/emoji/
-      emoji_index:     !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index:     !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:       # Highlighting code blocks            https://facelessuser.github.io/pymdown-extensions/extensions/highlight/
       linenums:     true
       use_pygments: true


### PR DESCRIPTION
- [x] I have verified that icons still work after this change 