### PR TITLE
Updates trigger docs styling and generation

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -143,6 +143,21 @@ h3, h4 {
 .md-typeset details.deprecated > summary > :first-child {
      margin: 0;   /* collapse the heading to its text height so the chevron centres on it */
 }
+.md-typeset details.deprecated > summary > :first-child::after {   /* "Deprecated" badge next to the title */
+     content: "Deprecated";
+     display: inline-block;
+     margin-left: 0.5em;
+     padding: 0.05em 0.45em;
+     border: 1px solid #ff9100;
+     border-radius: 0.6em;
+     font-size: 0.55em;
+     font-weight: 700;
+     letter-spacing: 0.05em;
+     text-transform: uppercase;
+     color: #ff9100;
+     vertical-align: middle;
+     white-space: nowrap;
+}
 
 tr td, table {
      border-width: 0 !important;

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -108,6 +108,42 @@ h3, h4 {
      box-shadow: 3px 3px 5px 0px #111111;
 }
 
+/* Deprecated entries: no admonition box, click the heading to expand */
+.md-typeset details.deprecated {
+     margin: 0;
+     padding: 0;
+     border: none;
+     border-radius: 0;
+     box-shadow: none;
+     background: transparent;
+     font-size: inherit;
+}
+.md-typeset details.deprecated > summary {
+     position: relative;         /* anchor the chevron to the summary, not the whole details */
+     margin: 0;
+     padding: 0 1.4rem 0 0;      /* room for the chevron on the right */
+     background: transparent;
+     border: none;
+     font-weight: inherit;
+     cursor: pointer;
+     list-style: none;
+}
+.md-typeset details.deprecated > summary::-webkit-details-marker {
+     display: none;
+}
+.md-typeset details.deprecated > summary::before {   /* drop the admonition icon */
+     display: none;
+}
+.md-typeset details.deprecated > summary::after {    /* keep the expand chevron, vertically centred on the heading */
+     top: 0;
+     bottom: 0;
+     right: 0;
+     margin: auto 0;
+}
+.md-typeset details.deprecated > summary > :first-child {
+     margin: 0;   /* collapse the heading to its text height so the chevron centres on it */
+}
+
 tr td, table {
      border-width: 0 !important;
 }

--- a/docs/scenarios/triggers/_trigger_docs.py
+++ b/docs/scenarios/triggers/_trigger_docs.py
@@ -1,0 +1,125 @@
+"""Shared generator for the trigger Effects and Conditions reference pages.
+
+Both pages are built the same way -- the only differences are the source
+definitions, the tricks file, the output path and a handful of display
+overrides. `effects.py` and `conditions.py` are thin wrappers that call
+`generate` with their own configuration.
+"""
+
+import json
+import urllib.request
+
+# Per-word display overrides (uppercased acronyms and spelled-out abbreviations).
+ACRONYMS = {"ai": "AI", "id": "ID", "ids": "IDs", "hp": "HP", "ui": "UI", "xy": "XY", "str": "String"}
+
+# A location can be given as a tile or a unit reference. When an entry carries
+# both attributes we hide the redundant unit-ref one and note in the tile
+# attribute's description that a unit is also accepted.
+LOCATION_ATTR = "location"
+LOCATION_UNIT_REF_ATTR = "location_unit_ref"
+
+
+def titleize(snake: str) -> str:
+    """Turn a snake_case identifier into a human-readable display name."""
+    chunks = []
+    for chunk in snake.split("/"):
+        words = [ACRONYMS.get(word, word.capitalize()) for word in chunk.split("_")]
+        chunks.append(" ".join(words))
+    return "/".join(chunks)
+
+
+def join_description(desc) -> str:
+    """Descriptions are either a string or a list of strings (one per sentence)."""
+    text = " ".join(desc) if isinstance(desc, list) else desc
+    return text.strip()
+
+
+def escape_cell(text: str) -> str:
+    """Escape characters that would otherwise break a Markdown table cell."""
+    return text.replace("|", "\\|")
+
+
+def generate(
+    *,
+    kind: str,
+    src: str,
+    tricks_path: str,
+    out_path: str,
+    attr_name_overrides: dict[str, str],
+) -> None:
+    """Render the reference page for a trigger `kind` ("effect" or "condition").
+
+    `kind` is used in the generated prose; `attr_name_overrides` tunes how
+    each entry's attributes are displayed.
+    """
+    with urllib.request.urlopen(src) as response:
+        entries = json.load(response)
+
+    with open(tricks_path, encoding="utf-8") as file:
+        tricks_by_id = {entry["id"]: entry["tricks"] for entry in json.load(file)}
+
+    # The `none` entry (id 0) is an empty placeholder, not a usable one.
+    entries = [entry for entry in entries if entry["id"] != 0]
+    entries.sort(key=lambda entry: titleize(entry["name"]))
+
+    out = """*Written by: Alian713 & KSneijders*
+
+---
+
+"""
+
+    for count, entry in enumerate(entries, 1):
+        if count > 1:
+            out += "---\n\n"
+
+        # Deprecated entries collapse under their heading (see css/style.css `.deprecated`).
+        deprecated = entry.get("deprecated")
+        if deprecated:
+            out += '<details class="deprecated" markdown="1">\n'
+            out += '<summary markdown="block">\n'
+            out += f"### ~~{titleize(entry['name'])}~~\n\n"
+            out += "</summary>\n"
+            out += f"!!! warning \"Deprecated since version {deprecated['version']}\"\n\n"
+            out += f"    {deprecated['reason']}\n\n"
+        else:
+            out += f"### {titleize(entry['name'])}\n\n"
+
+        description = join_description(entry["description"])
+
+        attr_names = {attr["name"] for attr in entry["attributes"]}
+        location_accepts_unit = LOCATION_ATTR in attr_names and LOCATION_UNIT_REF_ATTR in attr_names
+        attributes = [
+            attr for attr in entry["attributes"]
+            if not (location_accepts_unit and attr["name"] == LOCATION_UNIT_REF_ATTR)
+        ]
+
+        if not description.endswith((".", "!", "?")):
+            description += "."
+
+        if attributes:
+            out += f"{description} The configurations for this {kind} are as follows:\n\n"
+            out += "| Options | Description |\n"
+            out += "| :------- | :---------- |\n"
+            for attr in attributes:
+                display_name = attr_name_overrides.get(attr["name"], titleize(attr["name"]))
+                attr_desc = join_description(attr.get("description") or "")
+                if location_accepts_unit and attr["name"] == LOCATION_ATTR:
+                    attr_desc = attr_desc.replace("The tile", "The tile or unit")
+                attr_desc = escape_cell(attr_desc)
+                out += f"| {display_name} | {attr_desc} |\n"
+            out += "\n"
+        else:
+            out += f"{description}\n\n"
+
+        tricks = tricks_by_id.get(entry["id"])
+        if tricks:
+            out += f"Some useful tricks with this {kind}:\n\n"
+            for trick_count, trick in enumerate(tricks, 1):
+                out += f"{trick_count}. {trick}\n"
+            out += "\n"
+
+        if deprecated:
+            out += "</details>\n"
+
+    with open(out_path, "w", encoding="utf-8") as file:
+        file.write(out)

--- a/docs/scenarios/triggers/conditions/conditions.md
+++ b/docs/scenarios/triggers/conditions/conditions.md
@@ -39,7 +39,7 @@ This condition can be used to check if the source player has at least the specif
 
 ### And
 
-This condition acts as a logical AND combining the condition directly above and directly below. The operator precedence is AND > OR > no separator. For example, "A B OR C D" is interpreted as A and (B or C) and D. "A AND B OR C D" would be interpreted as ((A and B) or C) and D
+This condition acts as a logical AND combining the condition directly above and directly below. The operator precedence is AND > OR > no separator. For example, "A B OR C D" is interpreted as A and (B or C) and D. "A AND B OR C D" would be interpreted as ((A and B) or C) and D.
 
 ---
 
@@ -256,8 +256,11 @@ This condition can be used to check if the first unit's target is the second uni
 
 ---
 
+<details class="deprecated" markdown="1">
+<summary markdown="block">
 ### ~~Object Not Visible~~
 
+</summary>
 !!! warning "Deprecated since version 1.36"
 
     This condition should no longer be used. It does not work consistently (Even in Single Player). Use Object Visible (Multiplayer) with inverted checked instead.
@@ -268,10 +271,14 @@ This condition can be used to check if the specified object is currently NOT vis
 | :------- | :---------- |
 | Unit | The unit that must be currently not visible. |
 
+</details>
 ---
 
+<details class="deprecated" markdown="1">
+<summary markdown="block">
 ### ~~Object Selected~~
 
+</summary>
 !!! warning "Deprecated since version 1.36"
 
     This condition should no longer be used. It will cause desyncs in multiplayer games. Use Object Selected (Multiplayer) instead.
@@ -283,6 +290,7 @@ This condition can be used to check if the specified unit is currently selected 
 | Unit | The unit that must be currently selected. |
 | Inverted | When enabled, inverts the result of the condition |
 
+</details>
 ---
 
 ### Object Selected Multiplayer
@@ -297,8 +305,11 @@ This condition can be used to check if the specified unit is currently selected 
 
 ---
 
+<details class="deprecated" markdown="1">
+<summary markdown="block">
 ### ~~Object Visible~~
 
+</summary>
 !!! warning "Deprecated since version 1.36"
 
     This condition should no longer be used. It does not work consistently (Even in Single Player). Use Object Visible (Multiplayer) instead.
@@ -309,6 +320,7 @@ This condition can be used to check if the specified object is currently visible
 | :------- | :---------- |
 | Unit | The unit that must be currently visible. |
 
+</details>
 ---
 
 ### Object Visible Multiplayer
@@ -343,7 +355,7 @@ This condition can be used to check if the source player owns at least the speci
 
 ### Or
 
-This condition acts as a logical OR between the condition directly above and directly below. The operator precedence is AND > OR > no separator. For example, "A B OR C D" is interpreted as A and (B or C) and D. "A AND B OR C D" would be interpreted as ((A and B) or C) and D
+This condition acts as a logical OR between the condition directly above and directly below. The operator precedence is AND > OR > no separator. For example, "A B OR C D" is interpreted as A and (B or C) and D. "A AND B OR C D" would be interpreted as ((A and B) or C) and D.
 
 ---
 

--- a/docs/scenarios/triggers/conditions/conditions.py
+++ b/docs/scenarios/triggers/conditions/conditions.py
@@ -1,17 +1,16 @@
-import json
-import urllib.request
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.append(str(HERE.parent))
+
+from _trigger_docs import generate
 
 # Condition definitions are pulled straight from the AoE2ScenarioParser (v1) repository.
 SRC = "https://raw.githubusercontent.com/KSneijders/AoE2ScenarioParser/refs/heads/v1/effects.json/resources/scenario/triggers/conditions/condition-definitions-complete.json"
-# Handwritten tricks, keyed by condition id, that are not part of the upstream definitions.
-TRICKS = "./condition-tricks.json"
-OUT = "./conditions.md"
-
-# Per-word display overrides (uppercased acronyms and spelled-out abbreviations).
-ACRONYMS = {"ai": "AI", "id": "ID", "ids": "IDs", "hp": "HP", "ui": "UI", "xy": "XY", "str": "String"}
 
 # Attribute display names that read better than their auto-titleized form.
-ATTR_NAME_OVERRIDES = {
+ATTR_NAME_OVERRIDES: dict[str, str] = {
     "selected_unit_ref_ids": "Selected Units",
     "object_id": "Object",
     "object2_id": "Secondary Object",
@@ -24,78 +23,10 @@ ATTR_NAME_OVERRIDES = {
     "variable2_id": "Secondary Variable",
 }
 
-
-def titleize(snake: str) -> str:
-    """Turn a snake_case identifier into a human-readable display name."""
-    chunks = []
-    for chunk in snake.split("/"):
-        words = [ACRONYMS.get(word, word.capitalize()) for word in chunk.split("_")]
-        chunks.append(" ".join(words))
-    return "/".join(chunks)
-
-
-def join_description(desc) -> str:
-    """Descriptions are either a string or a list of strings (one per sentence)."""
-    text = " ".join(desc) if isinstance(desc, list) else desc
-    return text.strip()
-
-
-def escape_cell(text: str) -> str:
-    """Escape characters that would otherwise break a Markdown table cell."""
-    return text.replace("|", "\\|")
-
-
-with urllib.request.urlopen(SRC) as response:
-    conditions = json.load(response)
-
-with open(TRICKS, encoding="utf-8") as file:
-    tricks_by_id = {entry["id"]: entry["tricks"] for entry in json.load(file)}
-
-# The `none` condition (id 0) is an empty placeholder, not a usable condition.
-conditions = [condition for condition in conditions if condition["id"] != 0]
-conditions.sort(key=lambda condition: titleize(condition["name"]))
-
-out = """*Written by: Alian713 & KSneijders*
-
----
-
-"""
-
-for count, condition in enumerate(conditions, 1):
-    if count > 1:
-        out += "---\n\n"
-
-    deprecated = condition.get("deprecated")
-    if deprecated:
-        out += f"### ~~{titleize(condition['name'])}~~\n\n"
-        out += f"!!! warning \"Deprecated since version {deprecated['version']}\"\n\n"
-        out += f"    {deprecated['reason']}\n\n"
-    else:
-        out += f"### {titleize(condition['name'])}\n\n"
-
-    description = join_description(condition["description"])
-    attributes = condition["attributes"]
-
-    if attributes:
-        if not description.endswith((".", "!", "?")):
-            description += "."
-        out += f"{description} The configurations for this condition are as follows:\n\n"
-        out += "| Options | Description |\n"
-        out += "| :------- | :---------- |\n"
-        for attr in attributes:
-            display_name = ATTR_NAME_OVERRIDES.get(attr["name"], titleize(attr["name"]))
-            attr_desc = escape_cell(join_description(attr.get("description") or ""))
-            out += f"| {display_name} | {attr_desc} |\n"
-        out += "\n"
-    else:
-        out += f"{description}\n\n"
-
-    tricks = tricks_by_id.get(condition["id"])
-    if tricks:
-        out += "Some useful tricks with this condition:\n\n"
-        for trick_count, trick in enumerate(tricks, 1):
-            out += f"{trick_count}. {trick}\n"
-        out += "\n"
-
-with open(OUT, "w", encoding="utf-8") as file:
-    file.write(out)
+generate(
+    kind="condition",
+    src=SRC,
+    tricks_path=str(HERE / "condition-tricks.json"),
+    out_path=str(HERE / "conditions.md"),
+    attr_name_overrides=ATTR_NAME_OVERRIDES,
+)

--- a/docs/scenarios/triggers/effects/effects.md
+++ b/docs/scenarios/triggers/effects/effects.md
@@ -12,8 +12,11 @@ This effect can be used to communicate with an AI player by setting an AI Trigge
 
 ---
 
+<details class="deprecated" markdown="1">
+<summary markdown="block">
 ### ~~Acknowledge AI Signal~~
 
+</summary>
 !!! warning "Deprecated since version 1.40"
 
     This will cause a desync in multiplayer and recs, use the 'acknowledge_multiplayer_ai_signal' effect instead
@@ -24,6 +27,7 @@ This effect can be used to acknowledge a pending AI signal. The configurations f
 | :------- | :---------- |
 | AI Signal | The AI Signal ID to acknowledge |
 
+</details>
 ---
 
 ### Acknowledge Multiplayer AI Signal
@@ -69,8 +73,7 @@ This effect can be used to attack-move units. The configurations for this effect
 | :------- | :---------- |
 | Object | The type of unit to attack-move |
 | Source Player | The player whose units will attack-move |
-| Location | The tile to attack-move to |
-| Location Unit Ref | The target unit (as if it was right clicked) |
+| Location | The tile or unit to attack-move to |
 | Area | The area in which units will be attack-moved. When not set, units across the entire map are attack-moved |
 | Object Group | The units with this class will be affected by this effect |
 | Object Type | The units of this type will be affected by this effect |
@@ -1271,8 +1274,7 @@ This effect can be used to play a sound at a specific location or globally for t
 | Options | Description |
 | :------- | :---------- |
 | Source Player | The player who will hear the sound effect. |
-| Location | The tile to play the sound at. When not set, the sound will be played globally. |
-| Location Unit Ref | The unit whose position and rotation will be used to play the sound at. When not set, the sound will be played globally. |
+| Location | The tile or unit to play the sound at. When not set, the sound will be played globally. |
 | Global Sound | When enabled, the sound will be played regardless if the target is on screen. This is useful for existing game sounds that are considered '3D'. '3D' sounds are game sounds based on coordinates. '2D' sounds are sounds like GUI, button click or notification sounds. |
 | Sound Name | The name of the sound to play. |
 
@@ -1405,8 +1407,11 @@ This effect can be used to set the gather point (rally point) for buildings. The
 
 ---
 
+<details class="deprecated" markdown="1">
+<summary markdown="block">
 ### ~~Set Object Cost~~
 
+</summary>
 !!! warning "Deprecated since version 1.54"
 
     Use the `change_object_cost` effect instead
@@ -1420,6 +1425,7 @@ This effect can be used to set the cost for a specific type of unit. The configu
 | Quantity | The amount to set as the cost |
 | Resource | The type of resource for the cost |
 
+</details>
 ---
 
 ### Set Player Visibility
@@ -1469,8 +1475,7 @@ This effect can be used to order units to perform a specific action at a target 
 | :------- | :---------- |
 | Object | The type of unit to task |
 | Source Player | The player whose units will be tasked |
-| Location | The tile to send the tasked units to |
-| Location Unit Ref | The target unit (as if it was right clicked) |
+| Location | The tile or unit to send the tasked units to |
 | Area | The area in which units will be tasked. When not set, units across the entire map are tasked |
 | Object Group | The units with this class will be affected by this effect |
 | Object Type | The units of this type will be affected by this effect |
@@ -1542,8 +1547,7 @@ This effect can be used to unload units at a target location. The configurations
 | :------- | :---------- |
 | Object | The type of unit to unload |
 | Source Player | The player whose garrisoned units will be ordered to unload |
-| Location | The tile where garrisoned units will be unloaded |
-| Location Unit Ref | The target unit to unload at (as if it was right clicked) |
+| Location | The tile or unit where garrisoned units will be unloaded |
 | Area | The area in which garrisoned units will be ordered to unload. When not set, units across the entire map are ordered to unload |
 | Object Group | The units with this class will be affected by this effect |
 | Object Type | The units of this type will be affected by this effect |
@@ -1562,8 +1566,11 @@ This effect can be used to unlock specific gates. The configurations for this ef
 
 ---
 
+<details class="deprecated" markdown="1">
+<summary markdown="block">
 ### ~~Use Advanced Buttons~~
 
+</summary>
 !!! warning "Deprecated since version 1.36"
 
     This effect is no longer used. It was used to toggle the advanced buttons in the minimap interface before the Definitive Edition.
@@ -1574,3 +1581,4 @@ Some useful tricks with this effect:
 
 1. If you can't see the buttons for aggressive stance, and unit groups use this effect to enable them for yourself. That is all that this effect does, its useless otherwise
 
+</details>

--- a/docs/scenarios/triggers/effects/effects.py
+++ b/docs/scenarios/triggers/effects/effects.py
@@ -1,17 +1,16 @@
-import json
-import urllib.request
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.append(str(HERE.parent))
+
+from _trigger_docs import generate
 
 # Effect definitions are pulled straight from the AoE2ScenarioParser (v1) repository.
 SRC = "https://raw.githubusercontent.com/KSneijders/AoE2ScenarioParser/refs/heads/v1/effects.json/resources/scenario/triggers/effects/effect-definitions-complete.json"
-# Handwritten tricks, keyed by effect id, that are not part of the upstream definitions.
-TRICKS = "./effect-tricks.json"
-OUT = "./effects.md"
-
-# Per-word display overrides (uppercased acronyms and spelled-out abbreviations).
-ACRONYMS = {"ai": "AI", "id": "ID", "ids": "IDs", "hp": "HP", "ui": "UI", "xy": "XY", "str": "String"}
 
 # Attribute display names that read better than their auto-titleized form.
-ATTR_NAME_OVERRIDES = {
+ATTR_NAME_OVERRIDES: dict[str, str] = {
     "selected_unit_ref_ids": "Selected Units",
     "object_id": "Object",
     "object2_id": "Secondary Object",
@@ -22,78 +21,10 @@ ATTR_NAME_OVERRIDES = {
     "variable2_id": "Secondary Variable",
 }
 
-
-def titleize(snake: str) -> str:
-    """Turn a snake_case identifier into a human-readable display name."""
-    chunks = []
-    for chunk in snake.split("/"):
-        words = [ACRONYMS.get(word, word.capitalize()) for word in chunk.split("_")]
-        chunks.append(" ".join(words))
-    return "/".join(chunks)
-
-
-def join_description(desc) -> str:
-    """Descriptions are either a string or a list of strings (one per sentence)."""
-    text = " ".join(desc) if isinstance(desc, list) else desc
-    return text.strip()
-
-
-def escape_cell(text: str) -> str:
-    """Escape characters that would otherwise break a Markdown table cell."""
-    return text.replace("|", "\\|")
-
-
-with urllib.request.urlopen(SRC) as response:
-    effects = json.load(response)
-
-with open(TRICKS, encoding="utf-8") as file:
-    tricks_by_id = {entry["id"]: entry["tricks"] for entry in json.load(file)}
-
-# The `none` effect (id 0) is an empty placeholder, not a usable effect.
-effects = [effect for effect in effects if effect["id"] != 0]
-effects.sort(key=lambda effect: titleize(effect["name"]))
-
-out = """*Written by: Alian713 & KSneijders*
-
----
-
-"""
-
-for count, effect in enumerate(effects, 1):
-    if count > 1:
-        out += "---\n\n"
-    deprecated = effect.get("deprecated")
-
-    if deprecated:
-        out += f"### ~~{titleize(effect['name'])}~~\n\n"
-        out += f"!!! warning \"Deprecated since version {deprecated['version']}\"\n\n"
-        out += f"    {deprecated['reason']}\n\n"
-    else:
-        out += f"### {titleize(effect['name'])}\n\n"
-
-    description = join_description(effect["description"])
-    attributes = effect["attributes"]
-
-    if attributes:
-        if not description.endswith((".", "!", "?")):
-            description += "."
-        out += f"{description} The configurations for this effect are as follows:\n\n"
-        out += "| Options | Description |\n"
-        out += "| :------- | :---------- |\n"
-        for attr in attributes:
-            display_name = ATTR_NAME_OVERRIDES.get(attr["name"], titleize(attr["name"]))
-            attr_desc = escape_cell(join_description(attr.get("description") or ""))
-            out += f"| {display_name} | {attr_desc} |\n"
-        out += "\n"
-    else:
-        out += f"{description}\n\n"
-
-    tricks = tricks_by_id.get(effect["id"])
-    if tricks:
-        out += "Some useful tricks with this effect:\n\n"
-        for trick_count, trick in enumerate(tricks, 1):
-            out += f"{trick_count}. {trick}\n"
-        out += "\n"
-
-with open(OUT, "w", encoding="utf-8") as file:
-    file.write(out)
+generate(
+    kind="effect",
+    src=SRC,
+    tricks_path=str(HERE / "effect-tricks.json"),
+    out_path=str(HERE / "effects.md"),
+    attr_name_overrides=ATTR_NAME_OVERRIDES,
+)


### PR DESCRIPTION
(Summarized by AI, verified by KSneijders)

Refactors the documentation generation for trigger effects and conditions by introducing a shared Python script. This centralizes common logic, reducing duplication and simplifying future updates.

Improves the presentation of deprecated entries in the documentation:
*   Renders deprecated items as collapsible sections, enhancing readability and content organization.
*   Adds a distinctive "Deprecated" badge next to the title and provides a warning message detailing the deprecation version and reason.

Streamlines the display of 'location' related attributes by combining `location` and `location_unit_ref` into a single 'Location' option, indicating that both tile and unit references are accepted.

---

<img width="2327" height="1319" alt="image" src="https://github.com/user-attachments/assets/a6ac1e7f-6a70-4a97-bad6-04132336d680" />
